### PR TITLE
Exclude markdown files from formatting in deno.json

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -21,7 +21,7 @@
     "exclude": ["src/ui/", "dist/", "node_modules/"]
   },
   "fmt": {
-    "exclude": ["src/ui/", "dist/", "node_modules/"]
+    "exclude": ["src/ui/", "dist/", "node_modules/", "**/*.md"]
   },
   "exclude": ["src/ui/", "dist/", "node_modules/"],
   "imports": {


### PR DESCRIPTION
## Summary  
- Excluded markdown files from formatting in the `deno.json` configuration.  
- This change prevents markdown files from being affected by the formatting process.  

## Checklist  
- [x] I ran local verification (npm run verify)  
- [x] I updated docs or comments when behavior changed  
- [x] I kept changes scoped to the purpose of this PR  
- [x] I added or updated tests when applicable  

## Notes  
No migration notes or follow-up work required.

