### PR TITLE
docs: Remove release process details from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,28 +40,12 @@ Good first contributions:
 - Keep unrelated refactors out of the same PR.
 - Update docs when behavior or workflow changes.
 
-## Release Process
-
-- Normal feature and fix PRs merge into `main` as usual.
-- Releases are not created for every merge.
-- When a release is wanted, run the `prepare-release` workflow in GitHub
-  Actions.
-- Release Please creates or updates a dedicated release PR with version and
-  changelog updates.
-- Review that PR like any other change.
-- Merging the release PR triggers the publish workflow, which creates the Git
-  tag and GitHub Release.
-- GitHub Releases provide the stable source artifacts for this repository.
-- If release merges should stay owner-only, enforce that with branch protection
-  or repository permissions on `main`.
-
 ## Conventional Commits
 
-Release Please uses commit messages to calculate the next version.
+Please use conventional commit messages when making contributions:
 
 - `fix:` for patch releases
 - `feat:` for minor releases
 - `feat!:` or `BREAKING CHANGE:` for major releases
 
-If you primarily squash merge, set the PR title to the intended Conventional
 Commit format before merging.


### PR DESCRIPTION
Removed the release process section from CONTRIBUTING.md.

## Summary

Removed unnecessary release details from contributing file

## Checklist

- [x] I ran local verification (npm run verify)
- [x] I updated docs or comments when behavior changed
- [x] I kept changes scoped to the purpose of this PR
- [x] I added or updated tests when applicable

## Notes

No notes
